### PR TITLE
Bring back Registers#values_at

### DIFF
--- a/lib/liquid/registers.rb
+++ b/lib/liquid/registers.rb
@@ -44,6 +44,10 @@ module Liquid
     def key?(key)
       @changes.key?(key) || @static.key?(key)
     end
+
+    def values_at(*keys)
+      keys.collect { |key| fetch(key) }
+    end
   end
 
   # Alias for backwards compatibility

--- a/test/unit/registers_unit_test.rb
+++ b/test/unit/registers_unit_test.rb
@@ -60,6 +60,13 @@ class RegistersUnitTest < Minitest::Test
     assert_equal("default 2", result)
   end
 
+  def test_values_at
+    static_register = Registers.new(a: 1, b: 2)
+    assert_equal([1, 2], static_register.values_at(:a, :b))
+    assert_equal([2, 1], static_register.values_at(:b, :a))
+    assert_equal([2], static_register.values_at(:b))
+  end
+
   def test_key
     static_register = Registers.new(a: 1, b: 2)
     static_register[:b] = 22


### PR DESCRIPTION
Previously, registers returned from liquid have been good plain old hashes and thus users of the library were able to call `#value_at` on the registers.

This ability has been removed by the introduction of Liquid::Registers class.