### PR TITLE
Bring back Registers#each

### DIFF
--- a/lib/liquid/registers.rb
+++ b/lib/liquid/registers.rb
@@ -27,6 +27,16 @@ module Liquid
 
     UNDEFINED = Object.new
 
+    def keys
+      (@static.keys + @changes.keys).uniq
+    end
+
+    def each(&block)
+      keys.each do |key|
+        yield(key, fetch(key))
+      end
+    end
+
     def fetch(key, default = UNDEFINED, &block)
       if @changes.key?(key)
         @changes.fetch(key)

--- a/test/unit/registers_unit_test.rb
+++ b/test/unit/registers_unit_test.rb
@@ -36,6 +36,30 @@ class RegistersUnitTest < Minitest::Test
     assert_nil(static_register.delete(:d))
   end
 
+  def test_keys
+    static_register = Registers.new(a: 1, b: 2)
+    assert_equal([:a, :b], static_register.keys.sort)
+
+    static_register[:b] = 3
+    assert_equal([:a, :b], static_register.keys.sort)
+
+    static_register[:c] = 4
+    assert_equal([:a, :b, :c], static_register.keys.sort)
+  end
+
+  def test_each
+    static_register = Registers.new(a: 1, b: 2)
+
+    keys = []
+    vals = []
+    static_register.each do |key, val|
+      keys << key
+      vals << val
+    end
+    assert_equal([:a, :b], keys.sort)
+    assert_equal([1, 2], vals.sort)
+  end
+
   def test_fetch
     static_register = Registers.new(a: 1, b: 2)
     static_register[:b] = 22


### PR DESCRIPTION
Registers#each are being used in the template.rb anyway.

Basically merely passing registers from context to template options crashes liquid version 5.4, while it worked in liquid-5.3.

Addressing:
```
/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/template.rb:176:in `render': undefined method `each' for #<Liquid::Registers:0x00007f2b142ddfc0>

        options[:registers]&.each do |key, register|
                           ^^^^^^
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/template.rb:204:in `render!'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/jekyll-seo-tag-2.8.0/lib/jekyll-seo-tag.rb:36:in `render'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/tag.rb:51:in `render_to_output_buffer'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/block_body.rb:80:in `render_node'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/block_body.rb:230:in `render_node'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/block_body.rb:213:in `render_to_output_buffer'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/document.rb:41:in `render_to_output_buffer'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/template.rb:194:in `render'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/template.rb:204:in `render!'
```